### PR TITLE
package.json: define main module

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "po2json",
   "description": "Pure Javascript implementation of Uniforum message translation.",
   "version": "0.0.2",
+  "main": "./lib/po2json",
   "homepage": "https://github.com/mikeedwards/po2json",
   "author": {
     "name": "Joshua I. Miller",


### PR DESCRIPTION
This allows the module to be required from other modules, with
`require('po2json')` instead of `require('po2json/lib/po2json')`

Also required in order to be used with brunch, since brunch automatically
requires all installed modules.
