### PR TITLE
Properly escape linebreaks

### DIFF
--- a/lib/po2json.js
+++ b/lib/po2json.js
@@ -219,6 +219,7 @@ var parse_po_dequote = function(str) {
   if (match = str.match(/^"(.*)"/)) {
     str = match[1];
   }
-  str = str.replace(/\\"/g, '"');
+  str = str.replace(/\\"/g, '"')
+           .replace(/\\n/g, '\n');
   return str;
 };


### PR DESCRIPTION
This prevents linebreaks from being double escaped when the JSON is pretty printed.
