### PR TITLE
Bug fixes, enhancements, and an API change

### DIFF
--- a/bin/po2json
+++ b/bin/po2json
@@ -1,10 +1,13 @@
 #!/usr/bin/env node
 
 var po2json = require('../lib/po2json'),
-	fs = require('fs')
-    argv = process.argv;
+	fs = require('fs'),
+  assert = require('assert'),
+  argv = process.argv;
 
-po2json.parse(argv[2], function (result) {
+assert.equal(argv.length, 4, 'Usage: po2json <input_file.po> <output_file.json>');
+
+po2json.parse(argv[2], { stringify: true }, function (err, result) {
 	stream = fs.createWriteStream(argv[3], {});
     stream.write(result);
 });

--- a/lib/po2json.js
+++ b/lib/po2json.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /*
 PO parser from http://jsgettext.berlios.de/lib/Gettext.js
 adapted for Node.js and modified to be more like po2json.pl
@@ -8,9 +6,39 @@ adapted for Node.js and modified to be more like po2json.pl
 Further adapted to be used inside a node.js environment instead of the command line. Import with a require statement:
 var po2json = require('po2json.js')
 po2json.parse('filename', function(result) {
-   on parse complete callaback, result is the json string.
+   on parse complete callback, result is the json string.
 });
 - Daniel Roberts <danielrobertsdesign@gmail.com>
+
+Changed exports.parse to use node's convetional error-first callback style
+var po2json = require('po2json.js');
+po2json.parse('filename', function(err, result) {
+   on parse complete callaback, err is an Error or null and result is the json string.
+});
+
+Added exports.parseSync for synchronous parsing
+var po2json = require('po2json.js');
+var json;
+try {
+  json = po2json.parseSync('filename');
+} catch (e) {};
+
+Changed default behavior to return an object, rather than stringify.
+
+Added options to parser, presently: "pretty" (default: true) and "stringify" (default:false)
+
+Fixed bug in the non-pretty results.
+
+Fixed bugs in header parsing.
+
+Further async-ify the async parse function.
+
+Change bin script to use conventional node callback
+
+Change bin script to use options.stringify = true
+
+Add quick 'n dirty argument validation to bin script
+- Dan MacTough <dan@terraeclipse.com>
 */
 
 /*
@@ -36,22 +64,59 @@ USA.
 var fs = require('fs');
 var path = require('path');
 
-var pretty = true; 
-
 module.exports.parse = parse;
+module.exports.parseSync = parseSync;
 
-function parse (file, callback) {
-  fs.readFile(fs.realpathSync(file), 'utf8', function (err, data) {
-    if (err) throw err;
-    if (pretty) {
+function parse (file, options, callback) {
+  options = options || {};
+  if ('function' === typeof options) {
+    callback = options;
+    options = {};
+  }
+  if (!('pretty' in options)) {
+    options.pretty = true;
+  }
+  fs.realpath(file, function (err, realfile) {
+    if (err) return callback(err);
+    fs.readFile(realfile, 'utf8', function (err, data) {
+      if (err) return callback(err);
       var result = {};
-      result[path.basename(file, '.po')] = parse_po(data);
-      // perl JSON encoder uses three spaces (╯°□°）╯︵ ┻━┻
-      callback(JSON.stringify(result, null, '   '));
-    } else {
-      callback(JSON.stringify(parse_po(data)));
-    }
+      try {
+        result[path.basename(file, '.po')] = parse_po(data);
+      } catch (e) {
+        return callback(e);
+      }
+      process.nextTick(function(){
+        if (!options.stringify) {
+          callback(null, result);
+        } else if (options.pretty) {
+          // perl JSON encoder uses three spaces (╯°□°）╯︵ ┻━┻
+          callback(null, JSON.stringify(result, null, '   '));
+        } else {
+          callback(null, JSON.stringify(result));
+        }
+      });
+    });
   });
+}
+
+function parseSync (file, options) {
+  options = options || {};
+  if (!('pretty' in options)) {
+    options.pretty = true;
+  }
+  // Allow this to throw
+  var data = fs.readFileSync(fs.realpathSync(file), 'utf8');
+  var result = {};
+  result[path.basename(file, '.po')] = parse_po(data);
+  if (!options.stringify) {
+    return result;
+  } else if (options.pretty) {
+    // perl JSON encoder uses three spaces (╯°□°）╯︵ ┻━┻
+    return JSON.stringify(result, null, '   ');
+  } else {
+    return JSON.stringify(result);
+  }
 }
 
 var context_glue = "\004";
@@ -174,7 +239,7 @@ var parse_po = function(data) {
   // parse out the header
   if (rv[""] && rv[""][1]) {
     var cur = {};
-    var hlines = rv[""][1].split(/\\n/);
+    var hlines = rv[""][1].split(/\n/);
     for (var i=0; i<hlines.length; i++) {
       if (! hlines[i].length) continue;
 
@@ -190,7 +255,8 @@ var parse_po = function(data) {
         } else {
           // remove begining spaces if any (the perl script keeps them)
           //val = val.replace(/^\s+/, '');
-          cur[key] = val;
+          // I disagree. The perl script is wrong! -Dan MacTough
+          cur[key] = val.trim(); // strip leading and trailing space
         }
 
       } else {


### PR DESCRIPTION
Changed exports.parse to use node's convetional error-first callback style

```
var po2json = require('po2json.js');
po2json.parse('filename', function(err, result) {
  // on parse complete callback, err is an Error or null and result is the json string.
});
```

Added exports.parseSync for synchronous parsing

```
var po2json = require('po2json.js');
var json;
try {
  json = po2json.parseSync('filename');
} catch (e) {};
```

**Changed default behavior to return an object, rather than stringify.**

Added options to parser, presently: "pretty" (default: true) and "stringify" (default:false)

Fixed bug in the non-pretty results.

Fixed bugs in header parsing.

Further async-ify the async parse function.

Change bin script to use conventional node callback

Change bin script to use options.stringify = true

Add quick 'n dirty argument validation to bin script
