### PR TITLE
Fix the way to handle fuzzy flag

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -34,7 +34,7 @@ module.exports = function(buffer, options) {
     Object.keys(translations).forEach(function (key, i) {
       var t = translations[key],
           translationKey = context.length ? context + '\u0004' + key : key,
-          fuzzy = t.comments && t.comments.flag === 'fuzzy';
+          fuzzy = t.comments && t.comments.flag && t.comments.flag.match(/fuzzy/) !== null;
 
       if (!fuzzy || options.fuzzy)
         result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(t.msgstr);


### PR DESCRIPTION
I found a small issue regarding the way to handle "fuzzy" flag.
## Problem

[FLAG section in PO files can have multiple flags](http://www.gnu.org/savannah-checkouts/gnu/gettext/manual/html_node/PO-Files.html), but `po2json` understands "fuzzy" flag only when other flags aren't set.
## How to reproduce

Following PO file is valid, but "fuzzy" flag won't be set.

```
msgid ""
msgstr ""
"Project-Id-Version: dummy\n"
"Report-Msgid-Bugs-To: \n"
"POT-Creation-Date: 2014-07-04 02:03-0800\n"
"PO-Revision-Date: 2014-06-24 22:32+0000\n"
"Last-Translator: mahata <mahata777@gmail.com>\n"
"Language-Team: dummy\n"
"MIME-Version: 1.0\n"
"Content-Type: text/plain; charset=UTF-8\n"
"Content-Transfer-Encoding: 8bit\n"
"Language: ja\n"
"Plural-Forms: nplurals=1; plural=0;\n"
"X-Generator: dummy\n"

#, fuzzy, php-format
msgid "Hello, world!"
msgstr "こんにちは、世界！"
```
## Quick Fix

My PR will do a quick fix. It checks if FLAG section has "fuzzy" or not with a simple regular expression.
