### PR TITLE
fix for jed 1.1

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -40,17 +40,16 @@ module.exports = function(buffer, options) {
         if (options.format === 'mf') {
           result[translationKey] = t.msgstr[0];
         } else {
-          result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(t.msgstr);
+          result[translationKey] = [].concat(t.msgstr);
         }
       }
-      
+
       // In the case of fuzzy or empty messages, use msgid(/msgid_plural)
       if (options['fallback-to-msgid'] && (fuzzy && !options.fuzzy || t.msgstr[0] === '')) {
         if (options.format === 'mf') {
           result[translationKey] = key;
         } else {
-          result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ]
-              .concat(t.msgid_plural ? [key, t.msgid_plural] : [key]);
+          result[translationKey] = [].concat(t.msgid_plural ? [key, t.msgid_plural] : [key]);
         }
       }
 

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "test": "nodeunit test/"
   },
   "devDependencies": {
-    "nodeunit": "*",
-    "jed": "~1.0.2"
+    "jed": "^1.1.0",
+    "nodeunit": "*"
   },
   "keywords": [
     "i18n",

--- a/test/fixtures/en-empty.json
+++ b/test/fixtures/en-empty.json
@@ -13,28 +13,22 @@
       "language": "en"
    },
    "Hello, world!\n": [
-      null,
       "Hello, world!\n"
    ],
    "string context\u0004the contextual phrase": [
-      null,
       "the contextual phrase"
    ],
    "this is the first line\nthis is the next one\nbut this is the last\n": [
-      null,
       "this is the first line\nthis is the next one\nbut this is the last\n"
    ],
    "one product": [
-      "%d products",
       "one product",
       "%d products"
    ],
    "A sentence with \"quotation\" marks.": [
-      null,
       "A sentence with \"quotation\" marks."
    ],
    "A fuzzy translation": [
-      null,
       "A fuzzy translation"
    ]
 }

--- a/test/fixtures/pl-jed.json
+++ b/test/fixtures/pl-jed.json
@@ -8,25 +8,20 @@
             "lang": "pl"
          },
          "Hello, world!\n": [
-            null,
             "Witaj, świecie!\n"
          ],
          "this is the first line\nthis is the next one\nbut this is the last\n": [
-            null,
             "to jest pierwsza linia\nto jest następny\nale to jest ostatnia\n"
          ],
          "one product": [
-            "%d products",
             "jeden produkt",
             "%d produkty",
             "%d produktów"
          ],
          "A sentence with \"quotation\" marks.": [
-            null,
             "Zdanie w \"cudzysłowie\"."
          ],
          "string context\u0004the contextual phrase": [
-            null,
             "zwrot kontekstowe"
          ]
       }

--- a/test/fixtures/pl.json
+++ b/test/fixtures/pl.json
@@ -13,25 +13,20 @@
       "language": "pl"
    },
    "Hello, world!\n": [
-      null,
       "Witaj, świecie!\n"
    ],
    "this is the first line\nthis is the next one\nbut this is the last\n": [
-      null,
       "to jest pierwsza linia\nto jest następny\nale to jest ostatnia\n"
    ],
    "one product": [
-      "%d products",
       "jeden produkt",
       "%d produkty",
       "%d produktów"
    ],
    "A sentence with \"quotation\" marks.": [
-      null,
       "Zdanie w \"cudzysłowie\"."
    ],
    "string context\u0004the contextual phrase": [
-      null,
       "zwrot kontekstowe"
    ]
 }


### PR DESCRIPTION
fix #31 ?

I understand that there's a bit of a weird stuff for the "one product" key.

That is why it should be "%d product", AND in the translation for the correct pluralization form you then put "One product".

That way you can differentiate between the keys "one product" for straight gettext with no plural support, or "%d product".

Imo it's the only strange thing here going on. If you have some plural stuff, always have a %d in the base key. That way there's no ambiguity.

Please let me know what you think.
