### PR TITLE
Removed lodash dependency

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,5 +1,3 @@
-var _ = require("lodash");
-
 /**
  * Parse PO buffer to JSON
  *
@@ -19,7 +17,10 @@ module.exports = function(buffer, options) {
     format: 'raw',
     domain: 'messages'
   };
-  options = _.defaults( options, defaults );
+
+  for (var property in defaults) {
+    options[property] = 'undefined' !== typeof options[property] ? options[property] : defaults[property];
+  }
 
   // Parse the PO file
   var parsed = require('gettext-parser').po.parse( buffer );
@@ -43,7 +44,7 @@ module.exports = function(buffer, options) {
           result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(t.msgstr);
         }
       }
-      
+
       // In the case of fuzzy or empty messages, use msgid(/msgid_plural)
       if (options['fallback-to-msgid'] && (fuzzy && !options.fuzzy || t.msgstr[0] === '')) {
         if (options.format === 'mf') {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "po"
   ],
   "dependencies": {
-    "lodash": "~2.4.1",
     "nomnom": "1.8.0",
     "gettext-parser": "~0.2.0"
   }


### PR DESCRIPTION
Hi there,

Just a small commit that removes the lodash dependency. I found it a bit overkill looking at the source code that this lib was only required for just the `_.defaults()` method. Even if this line is replaced by a `for` statement that may look uglier, I find it more suitable for the script needs.

It is really a personal point of view, feel free to merge it if you feel that way, reject it otherwise, won't hurt my feelings :)

Tests are passing.

Best