### PR TITLE
Include charset option to the gettext-parser po parser

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -24,7 +24,7 @@ module.exports = function(buffer, options) {
   }
 
   // Parse the PO file
-  var parsed = require('gettext-parser').po.parse( buffer, charset );
+  var parsed = require('gettext-parser').po.parse( buffer, defaults.charset );
 
   // Create gettext/Jed compatible JSON from parsed data
   var result = {},

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -15,7 +15,8 @@ module.exports = function(buffer, options) {
     fuzzy: false,
     stringify: false,
     format: 'raw',
-    domain: 'messages'
+    domain: 'messages',
+    charset: 'utf8'
   };
 
   for (var property in defaults) {
@@ -23,7 +24,7 @@ module.exports = function(buffer, options) {
   }
 
   // Parse the PO file
-  var parsed = require('gettext-parser').po.parse( buffer );
+  var parsed = require('gettext-parser').po.parse( buffer, charset );
 
   // Create gettext/Jed compatible JSON from parsed data
   var result = {},


### PR DESCRIPTION
For some languages the resulting json is incorrect because the encoding not being passed to gettext-parser.
