### PR TITLE
jed1.x: use msgid_plural when there is no translation

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -75,6 +75,11 @@ module.exports = function(buffer, options) {
     if (options.format === 'jed1.x'){
       for (key in result) {
         if (result.hasOwnProperty(key) && key !== ''){
+          for (var i = 2; i < result[key].length; i++){
+            if ('' === result[key][i]){
+              result[key][i] = result[key][0];
+            }
+          }
           result[key].shift();
         }
       }

--- a/test/fixtures/pl-jed.json
+++ b/test/fixtures/pl-jed.json
@@ -28,6 +28,12 @@
          "string context\u0004the contextual phrase": [
             null,
             "zwrot kontekstowe"
+         ],
+         "a product": [
+            "%d products",
+            "",
+            "",
+            ""
          ]
       }
    }

--- a/test/fixtures/pl-jed1.x.json
+++ b/test/fixtures/pl-jed1.x.json
@@ -23,6 +23,11 @@
          ],
          "string context\u0004the contextual phrase": [
             "zwrot kontekstowe"
+         ],
+         "a product": [
+            "",
+            "%d products",
+            "%d products"
          ]
       }
    }

--- a/test/fixtures/pl.json
+++ b/test/fixtures/pl.json
@@ -33,5 +33,11 @@
    "string context\u0004the contextual phrase": [
       null,
       "zwrot kontekstowe"
+   ],
+   "a product": [
+      "%d products",
+      "",
+      "",
+      ""
    ]
 }

--- a/test/fixtures/pl.po
+++ b/test/fixtures/pl.po
@@ -49,3 +49,10 @@ msgstr "Zdanie w \"cudzysłowie\"."
 #, fuzzy
 msgid "A fuzzy translation"
 msgstr "Tłumaczenie rozmyta"
+
+#: test.js:7
+msgid "a product"
+msgid_plural "%d products"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""


### PR DESCRIPTION
otherwise the plural form is lost when there is no translation given