### PR TITLE
wrap msgstr into an Array to be able translate correctly languages without plural form (one form provided)

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ po2json.parseFile('messages.po', { format: 'jed' }, function (err, jsonData) {
 });
 ```
 
+### Running tests
+```
+nodeunit test/
+```
+
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [grunt](https://github.com/gruntjs/grunt).
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -32,6 +32,7 @@ module.exports = function(buffer, options) {
 
   Object.keys(contexts).forEach(function (context) {
     var translations = parsed.translations[context];
+    var pluralForms = parsed.headers['plural-forms'];
 
     Object.keys(translations).forEach(function (key, i) {
       var t = translations[key],
@@ -42,7 +43,12 @@ module.exports = function(buffer, options) {
         if (options.format === 'mf') {
           result[translationKey] = t.msgstr[0];
         } else {
-          result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(t.msgstr);
+          if(pluralForms == 'nplurals=1; plural=0;') {
+            msgstr = t.msgid_plural ? [t.msgstr] : t.msgstr
+            result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(msgstr);
+          } else {
+            result[translationKey] = [ t.msgid_plural ? t.msgid_plural : null ].concat(t.msgstr);
+          }
         }
       }
 

--- a/test/fixtures/ja.json
+++ b/test/fixtures/ja.json
@@ -1,0 +1,16 @@
+{
+   "": {
+     "project-id-version": "VERSION",
+     "po-revision-date": "2016-08-08 14:08+0000",
+     "last-translator": "FULL NAME <EMAIL@ADDRESS>",
+     "language-team": "LANGUAGE TEAM <EMAIL@ADDRESS>",
+     "language": "ja",
+     "mime-version": "1.0",
+     "content-type": "text/plain; charset=UTF-8",
+     "content-transfer-encoding": "8bit",
+     "plural-forms": "nplurals=1; plural=0;"
+   },
+   "♂ Male": [ null, "男性" ],
+   "partner application": [ "partner applications", [ "パートナーアプリ" ] ],
+   "result": [ "results", [ "検索結果" ] ]
+}

--- a/test/fixtures/ja.po
+++ b/test/fixtures/ja.po
@@ -1,0 +1,22 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: VERSION\n"
+"PO-Revision-Date: 2016-08-08 14:08+0000\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE TEAM <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "♂ Male"
+msgstr "男性"
+
+msgid "partner application"
+msgid_plural "partner applications"
+msgstr[0] "パートナーアプリ"
+
+msgid "result"
+msgid_plural "results"
+msgstr[0] "検索結果"

--- a/test/po2json_test.js
+++ b/test/po2json_test.js
@@ -114,3 +114,17 @@ module.exports["parseFileSync"] = {
     test.done();
   }
 }
+
+module.exports["parse with Plural-Forms == nplurals=1; plural=0;"] = {
+  setUp: function(callback){
+    this.po = fs.readFileSync(__dirname + "/fixtures/ja.po");
+    this.json = JSON.parse(fs.readFileSync(__dirname + "/fixtures/ja.json", "utf-8"));
+    callback();
+  },
+
+  parse: function(test){
+    var parsed = po2json.parse(this.po);
+    test.deepEqual(parsed, this.json);
+    test.done();
+  }
+}


### PR DESCRIPTION
Hey,

I prepared a patch for Japanese. Does it make sense to merge in?
I also thought about fixing it directly in `gettext-parser` but it would require additional amount of work.

Cheers!