### PR TITLE
Fix parsing of .po files with no headers

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -66,7 +66,9 @@ module.exports = function(buffer, options) {
   });
 
   // Attach headers (overwrites any empty translation keys that may have somehow gotten in)
-  result[''] = parsed.headers;
+  if (parsed.headers) {
+    result[''] = parsed.headers;
+  }
 
   if (options.format === 'mf') {
     delete result[''];

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -32,7 +32,7 @@ module.exports = function(buffer, options) {
 
   Object.keys(contexts).forEach(function (context) {
     var translations = parsed.translations[context];
-    var pluralForms = parsed.headers['plural-forms'];
+    var pluralForms = parsed.headers ? parsed.headers['plural-forms'] : '';
 
     Object.keys(translations).forEach(function (key, i) {
       var t = translations[key],

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "po2json",
   "description": "Convert PO files to JSON",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "homepage": "https://github.com/mikeedwards/po2json",
   "author": {
     "name": "Joshua I. Miller",
@@ -33,6 +33,10 @@
     },
     {
       "name": "rafalt-iRonin"
+    },
+    {
+      "name": "Alex Petty",
+      "email": "pettyalex@gmail.com"
     }
   ],
   "repository": {

--- a/test/fixtures/en-no-header.json
+++ b/test/fixtures/en-no-header.json
@@ -1,0 +1,6 @@
+{
+   "Hello World": [
+      null,
+      "Hello World"
+   ]
+}

--- a/test/fixtures/en-no-header.po
+++ b/test/fixtures/en-no-header.po
@@ -1,0 +1,4 @@
+# Very minimal .po
+
+msgid "Hello World"
+msgstr "Hello World"

--- a/test/po2json_test.js
+++ b/test/po2json_test.js
@@ -128,3 +128,17 @@ module.exports["parse with Plural-Forms == nplurals=1; plural=0;"] = {
     test.done();
   }
 }
+
+module.exports["parse with no headers"] ={
+  setUp: function(callback){
+    this.po = fs.readFileSync(__dirname + "/fixtures/en-no-header.po");
+    this.json = JSON.parse(fs.readFileSync(__dirname + "/fixtures/en-no-header.json", "utf-8"));
+    callback();
+  },
+
+  parse: function(test){
+    var parsed = po2json.parse(this.po);
+    test.deepEqual(parsed, this.json);
+    test.done();
+  }
+}


### PR DESCRIPTION
We have some header-less .po files that were broken by the plurals support update. 