### PR TITLE
Remove invalid "main" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "bin": {
     "po2json": "bin/po2json"
   },
-  "main": "./lib/po2json",
   "engines": {
     "node": ">=10.0"
   },


### PR DESCRIPTION
Node v16 gives the following warning when requiring po2json:

```
(node:11780) [DEP0128] DeprecationWarning: Invalid 'main' field in '.../node_modules/po2json/package.json' of './lib/po2json'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Since "./lib/po2json" doesn't exist and the true entry point is actually index.js (the default), I'm removing the field, which silences the warning.